### PR TITLE
Fixes DSN issue and get threaded option

### DIFF
--- a/django-oracle-drcp/base.py
+++ b/django-oracle-drcp/base.py
@@ -54,4 +54,3 @@ class DatabaseWrapper(DjDatabaseWrapper):
         if self.connection is not None:
             with self.wrap_database_errors:
                 return self.pool.release(self.connection)
-

--- a/django-oracle-drcp/base.py
+++ b/django-oracle-drcp/base.py
@@ -2,6 +2,7 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.oracle.base import *
 from django.db.backends.oracle.base import DatabaseWrapper as DjDatabaseWrapper
+from django.db.backends.oracle.utils import convert_unicode
 
 import cx_Oracle
 
@@ -20,10 +21,16 @@ class DatabaseWrapper(DjDatabaseWrapper):
             raise ImproperlyConfigured('POOL database option requires \'min\', \'max\', and \'increment\'')
         if not all(isinstance(val, int) for val in pool_config.values()):
             raise ImproperlyConfigured('POOL database option values must be numeric')
+
+        options = self.settings_dict.get('OPTIONS', None)
+        threaded = options.get('threaded', False) if options else False
+
         self.pool = cx_Oracle.SessionPool(
             user=self.settings_dict['USER'],
             password=self.settings_dict['PASSWORD'],
-            dsn=self.settings_dict['NAME'], **pool_config)
+            dsn=self.get_dsn(),
+            threaded=threaded,
+            **pool_config)
 
     def get_new_connection(self, conn_params):
         conn_params.update({
@@ -31,7 +38,20 @@ class DatabaseWrapper(DjDatabaseWrapper):
         })
         return super(DatabaseWrapper, self).get_new_connection(conn_params)
 
+    def get_dsn(self):
+        settings_dict = self.settings_dict
+
+        if settings_dict['PORT']:
+            dsn = self.Database.makedsn(settings_dict['HOST'],
+                                   int(settings_dict['PORT']),
+                                   settings_dict['NAME'])
+        else:
+            dsn = settings_dict['NAME']
+
+        return dsn
+
     def _close(self):
         if self.connection is not None:
             with self.wrap_database_errors:
                 return self.pool.release(self.connection)
+


### PR DESCRIPTION
The current implementation does not allow to create a pool for a remove DB. This commit fixes it.

It also adds the thread option to the PoolSession config.